### PR TITLE
bsdgrep: for -r, use the working directory if none specified

### DIFF
--- a/toolbox/upstream-netbsd/usr.bin/grep/grep.c
+++ b/toolbox/upstream-netbsd/usr.bin/grep/grep.c
@@ -685,7 +685,7 @@ main(int argc, char *argv[])
 	if ((aargc == 0 || aargc == 1) && !Hflag)
 		hflag = true;
 
-	if (aargc == 0)
+	if (aargc == 0 && dirbehave != DIR_RECURSE)
 		exit(!procfile("-"));
 
 	if (dirbehave == DIR_RECURSE)

--- a/toolbox/upstream-netbsd/usr.bin/grep/util.c
+++ b/toolbox/upstream-netbsd/usr.bin/grep/util.c
@@ -117,6 +117,7 @@ grep_tree(char **argv)
 	char *d, *dir = NULL;
 	int c, fts_flags;
 	bool ok;
+	const char *wd[] = { ".", NULL };
 
 	c = fts_flags = 0;
 
@@ -134,7 +135,9 @@ grep_tree(char **argv)
 
 	fts_flags |= FTS_NOSTAT | FTS_NOCHDIR;
 
-	if (!(fts = fts_open(argv, fts_flags, NULL)))
+	fts = fts_open((argv[0] == NULL) ?
+	    ((char * const *)(uintptr_t)(const void *)wd) : argv, fts_flags, NULL);
+	if (fts == NULL)
 		err(2, "fts_open");
 	while ((p = fts_read(fts)) != NULL) {
 		switch (p->fts_info) {


### PR DESCRIPTION
This is more sensible than the previous behaviour of grepping stdin,
and matches newer GNU grep behaviour.

PR:		216307
Submitted by:	Kyle Evans <kevans91 at ksu.edu>
Reviewed by:	cem, emaste, ngie
Relnotes:	Yes
Differential Revision:	https://reviews.freebsd.org/

Change-Id: I9dc42c4105c35c42c6b195c880c70f4398852886